### PR TITLE
Add basic functions to convert skeleton image to a skeleton graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "numpy>=2.0.2",
     "scikit-image>=0.24.0",
     "skan>=0.12.2",
+    "splinebox>=0.3.0",
 ]
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ name = "skeleplex-v2"
 dynamic = ["version"]
 description = "A Python package for analyzing skeletons."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "BSD-3-Clause" }
 authors = [{ name = "Kevin Yamauchi", email = "kevin.yamauchi@gmail.com" }]
 # https://pypi.org/classifiers/
@@ -27,7 +27,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -76,7 +75,7 @@ repository = "https://github.com/kevinyamauchi/skeleplex-v2"
 # https://docs.astral.sh/ruff
 [tool.ruff]
 line-length = 88
-target-version = "py39"
+target-version = "py310"
 src = ["src"]
 
 # https://docs.astral.sh/ruff/rules

--- a/scripts/view_simple_t.py
+++ b/scripts/view_simple_t.py
@@ -1,16 +1,25 @@
 """Script to view the simple T skeleton image."""
 
+import json
+from pprint import pprint
+
 import napari
+import networkx as nx
 
 from skeleplex.data.skeleton_image import simple_t
 from skeleplex.graph.image_to_graph import image_to_graph_skan
+from skeleplex.graph.skeleton_graph import skeleton_graph_encoder
 
 # create the image
 image = simple_t()
 
 # make the graph
-summary_table = image_to_graph_skan(image)
-print(summary_table)
+skeleton_graph = image_to_graph_skan(image)
+# print(skeleton_graph)
+
+json_data = nx.node_link_data(skeleton_graph, edges="edges")
+pprint(json_data)
+pprint(json.dumps(json_data, indent=4, default=skeleton_graph_encoder))
 
 viewer = napari.Viewer()
 viewer.add_image(image, name="simple T skeleton")

--- a/scripts/view_simple_t.py
+++ b/scripts/view_simple_t.py
@@ -8,7 +8,10 @@ import networkx as nx
 
 from skeleplex.data.skeleton_image import simple_t
 from skeleplex.graph.image_to_graph import image_to_graph_skan
-from skeleplex.graph.skeleton_graph import skeleton_graph_encoder
+from skeleplex.graph.skeleton_graph import (
+    skeleton_graph_decoder,
+    skeleton_graph_encoder,
+)
 
 # create the image
 image = simple_t()
@@ -19,7 +22,10 @@ skeleton_graph = image_to_graph_skan(image)
 
 json_data = nx.node_link_data(skeleton_graph, edges="edges")
 pprint(json_data)
-pprint(json.dumps(json_data, indent=4, default=skeleton_graph_encoder))
+json_string = json.dumps(json_data, indent=4, default=skeleton_graph_encoder)
+pprint(json_string)
+
+pprint(json.loads(json_string, object_hook=skeleton_graph_decoder))
 
 viewer = napari.Viewer()
 viewer.add_image(image, name="simple T skeleton")

--- a/scripts/view_simple_t.py
+++ b/scripts/view_simple_t.py
@@ -1,0 +1,14 @@
+"""Script to view the simple T skeleton image."""
+
+import napari
+
+from skeleplex.data.skeleton_image import simple_t
+
+# create the image
+image = simple_t()
+
+viewer = napari.Viewer()
+viewer.add_image(image, name="simple T skeleton")
+
+if __name__ == "__main__":
+    napari.run()

--- a/scripts/view_simple_t.py
+++ b/scripts/view_simple_t.py
@@ -3,9 +3,14 @@
 import napari
 
 from skeleplex.data.skeleton_image import simple_t
+from skeleplex.graph.image_to_graph import image_to_graph_skan
 
 # create the image
 image = simple_t()
+
+# make the graph
+summary_table = image_to_graph_skan(image)
+print(summary_table)
 
 viewer = napari.Viewer()
 viewer.add_image(image, name="simple T skeleton")

--- a/src/skeleplex/data/__init__.py
+++ b/src/skeleplex/data/__init__.py
@@ -1,0 +1,1 @@
+"""Example data."""

--- a/src/skeleplex/data/__init__.py
+++ b/src/skeleplex/data/__init__.py
@@ -1,1 +1,5 @@
 """Example data."""
+
+from skeleplex.data.skeleton_image import simple_t
+
+__all__ = ["simple_t"]

--- a/src/skeleplex/data/skeleton_image.py
+++ b/src/skeleplex/data/skeleton_image.py
@@ -1,0 +1,30 @@
+"""Example skeleton images."""
+
+import numpy as np
+from skimage.draw import line
+
+
+def simple_t() -> np.ndarray:
+    """Make an image with a simple T skeleton.
+
+    Returns
+    -------
+    np.ndarray
+        A binary image with a simple T skeleton.
+        The image has shape (20, 20, 20)
+    """
+    # node coordinates for each branch
+    branch_coordinates = [
+        [(10, 5), (10, 10)],
+        [(10, 10), (10, 15)],
+        [(10, 10), (15, 10)],
+    ]
+
+    # draw the image
+    image = np.zeros((20, 20, 20), dtype=bool)
+
+    for branch in branch_coordinates:
+        rr, cc = line(*branch[0], *branch[1])
+        image[10, rr, cc] = 1
+
+    return image

--- a/src/skeleplex/graph/constants.py
+++ b/src/skeleplex/graph/constants.py
@@ -1,0 +1,6 @@
+"""Constants used for interacting with the graph objects.
+
+Generally, these are property or key names.
+"""
+
+NODE_COORDINATE_KEY = "node_coordinate"

--- a/src/skeleplex/graph/image_to_graph.py
+++ b/src/skeleplex/graph/image_to_graph.py
@@ -5,9 +5,18 @@ import numpy as np
 from skan.csr import Skeleton as SkanSkeleton
 from skan.csr import summarize
 
+from skeleplex.graph.constants import NODE_COORDINATE_KEY
+
 
 def image_to_graph_skan(skeleton_image: np.ndarray):
-    """Convert a skeleton image to a graph using skan."""
+    """Convert a skeleton image to a graph using skan.
+
+    Parameters
+    ----------
+    skeleton_image : np.ndarray
+        The image to convert to a skeleton graph.
+        The image should be a binary image and already skeletonized.
+    """
     # make the skeleton
     skeleton = SkanSkeleton(skeleton_image=skeleton_image)
     summary_table = summarize(skeleton, separator="_")
@@ -35,4 +44,13 @@ def image_to_graph_skan(skeleton_image: np.ndarray):
                 "path": skeleton.path_coordinates(index),
             },
         )
+
+    # add the node coordinates
+    new_node_data = {}
+    for node_index, node_data in skeleton_graph.nodes(data=True):
+        node_data[NODE_COORDINATE_KEY] = np.asarray(skeleton.coordinates[node_index])
+        new_node_data[node_index] = node_data
+
+    nx.set_node_attributes(skeleton_graph, new_node_data)
+
     return skeleton_graph

--- a/src/skeleplex/graph/image_to_graph.py
+++ b/src/skeleplex/graph/image_to_graph.py
@@ -2,13 +2,16 @@
 
 import networkx as nx
 import numpy as np
+import splinebox
 from skan.csr import Skeleton as SkanSkeleton
 from skan.csr import summarize
 
 from skeleplex.graph.constants import NODE_COORDINATE_KEY
 
 
-def image_to_graph_skan(skeleton_image: np.ndarray):
+def image_to_graph_skan(
+    skeleton_image: np.ndarray, max_spline_knots: int = 10
+) -> nx.MultiGraph:
     """Convert a skeleton image to a graph using skan.
 
     Parameters
@@ -16,6 +19,11 @@ def image_to_graph_skan(skeleton_image: np.ndarray):
     skeleton_image : np.ndarray
         The image to convert to a skeleton graph.
         The image should be a binary image and already skeletonized.
+    max_spline_knots : int
+        The maximum number of knots to use for the spline fit to the branch path.
+        If the number of data points in the branch is less than this number,
+        the spline will use n_data_points - 1 knots.
+        See the splinebox Spline class docs for more information.
     """
     # make the skeleton
     skeleton = SkanSkeleton(skeleton_image=skeleton_image)
@@ -36,13 +44,25 @@ def image_to_graph_skan(skeleton_image: np.ndarray):
         index = row.Index
         i = row.node_id_src
         j = row.node_id_dst
+
+        # fit a spline to the path
+        # todo: factor our to spline module
+        # todo: reconsider how the number of knots is set
+        spline_path = skeleton.path_coordinates(index)
+        n_points = len(spline_path)
+        if n_points <= max_spline_knots:
+            n_spline_knots = n_points - 1
+        else:
+            n_spline_knots = max_spline_knots
+        basis_function = splinebox.B3()
+        spline = splinebox.Spline(n_spline_knots, basis_function)
+        spline.fit(spline_path)
+
         # Nodes are added if they don't exist so only need to add edges
         skeleton_graph.add_edge(
             i,
             j,
-            **{
-                "path": skeleton.path_coordinates(index),
-            },
+            **{"path": spline_path, "spline": spline},
         )
 
     # add the node coordinates

--- a/src/skeleplex/graph/image_to_graph.py
+++ b/src/skeleplex/graph/image_to_graph.py
@@ -1,1 +1,38 @@
 """Utilities to convert a skeleton image to a graph."""
+
+import networkx as nx
+import numpy as np
+from skan.csr import Skeleton as SkanSkeleton
+from skan.csr import summarize
+
+
+def image_to_graph_skan(skeleton_image: np.ndarray):
+    """Convert a skeleton image to a graph using skan."""
+    # make the skeleton
+    skeleton = SkanSkeleton(skeleton_image=skeleton_image)
+    summary_table = summarize(skeleton, separator="_")
+
+    # get all of the nodes
+    # this might be slow - may need to speed up
+    # source_nodes = set(summary_table["node_id_src"])
+    # destination_nodes = set(summary_table["node_id_dst"])
+    # all_nodes = source_nodes.union(destination_nodes)
+
+    skeleton_graph = nx.MultiGraph(
+        shape=skeleton.skeleton_shape, dtype=skeleton.skeleton_dtype
+    )
+    for row in summary_table.itertuples(name="Edge"):
+        # Iterate over the rows in the table.
+        # Each row is an edge in the graph
+        index = row.Index
+        i = row.node_id_src
+        j = row.node_id_dst
+        # Nodes are added if they don't exist so only need to add edges
+        skeleton_graph.add_edge(
+            i,
+            j,
+            **{
+                "path": skeleton.path_coordinates(index),
+            },
+        )
+    return skeleton_graph

--- a/src/skeleplex/graph/image_to_graph.py
+++ b/src/skeleplex/graph/image_to_graph.py
@@ -35,9 +35,7 @@ def image_to_graph_skan(
     # destination_nodes = set(summary_table["node_id_dst"])
     # all_nodes = source_nodes.union(destination_nodes)
 
-    skeleton_graph = nx.MultiGraph(
-        shape=skeleton.skeleton_shape, dtype=skeleton.skeleton_dtype
-    )
+    skeleton_graph = nx.MultiGraph()
     for row in summary_table.itertuples(name="Edge"):
         # Iterate over the rows in the table.
         # Each row is an edge in the graph

--- a/src/skeleplex/graph/skeleton_graph.py
+++ b/src/skeleplex/graph/skeleton_graph.py
@@ -4,7 +4,8 @@
 class SkeletonGraph:
     """Data class for a skeleton graph.
 
-    Attributes:
+    Attributes
+    ----------
         nodes: A list of nodes in the graph.
         edges: A list of edges in the graph.
     """

--- a/src/skeleplex/graph/skeleton_graph.py
+++ b/src/skeleplex/graph/skeleton_graph.py
@@ -2,10 +2,11 @@
 
 import numpy as np
 from splinebox import Spline
+from splinebox.spline_curves import _prepared_dict_for_constructor
 
 
 def skeleton_graph_encoder(object_to_encode):
-    """JSON encoder for the skeleton graph class.
+    """JSON encoder for the networkx skeleton graph.
 
     This function is to be used with the Python json.dump(s) functions
     as the `default` keyword argument.
@@ -21,6 +22,21 @@ def skeleton_graph_encoder(object_to_encode):
         spline_dict.update({"__class__": "splinebox.Spline"})
         return spline_dict
     raise TypeError(f"Object of type {type(object_to_encode)} is not JSON serializable")
+
+
+def skeleton_graph_decoder(json_object):
+    """JSON decoder for the networkx skeleton graph.
+
+    This function is to be used with the Python json.load(s) functions
+    as the `object_hook` keyword argument.
+    """
+    if "__class__" in json_object:
+        # all custom classes are identified by the __class__ key
+        if json_object["__class__"] == "splinebox.Spline":
+            json_object.pop("__class__")
+            spline_kwargs = _prepared_dict_for_constructor(json_object)
+            return Spline(**spline_kwargs)
+    return json_object
 
 
 class SkeletonGraph:

--- a/src/skeleplex/graph/skeleton_graph.py
+++ b/src/skeleplex/graph/skeleton_graph.py
@@ -1,5 +1,27 @@
 """Data class for a skeleton graph."""
 
+import numpy as np
+from splinebox import Spline
+
+
+def skeleton_graph_encoder(object_to_encode):
+    """JSON encoder for the skeleton graph class.
+
+    This function is to be used with the Python json.dump(s) functions
+    as the `default` keyword argument.
+    """
+    if isinstance(object_to_encode, np.ndarray):
+        return object_to_encode.tolist()
+    elif isinstance(object_to_encode, Spline):
+        spline_dict = object_to_encode._to_dict(version=2)
+        if "__class__" in spline_dict:
+            raise ValueError(
+                "The Spline object to encode already has a '__class__' key."
+            )
+        spline_dict.update({"__class__": "splinebox.Spline"})
+        return spline_dict
+    raise TypeError(f"Object of type {type(object_to_encode)} is not JSON serializable")
+
 
 class SkeletonGraph:
     """Data class for a skeleton graph.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Fixtures for testing with Pytest."""
+
+import pytest
+
+from skeleplex.data.skeleton_image import simple_t
+from skeleplex.graph.image_to_graph import image_to_graph_skan
+from skeleplex.graph.skeleton_graph import SkeletonGraph
+
+
+@pytest.fixture
+def simple_t_skeleton_graph():
+    """Return the simple T skeleton as a graph.
+
+    Todo: replace with valid data rather than a processed object.
+    """
+    skeleton_image = simple_t()
+    graph = image_to_graph_skan(skeleton_image=skeleton_image)
+
+    return SkeletonGraph(graph=graph)

--- a/tests/graph/test_image_to_graph.py
+++ b/tests/graph/test_image_to_graph.py
@@ -1,0 +1,22 @@
+""" "Tests for the skeleplex.graph.image_to_graph module."""
+
+import networkx as nx
+
+from skeleplex.data import simple_t
+from skeleplex.graph.constants import NODE_COORDINATE_KEY
+from skeleplex.graph.image_to_graph import image_to_graph_skan
+
+
+def test_image_to_graph_skan():
+    """Test converting a skeleton image to graph using skan."""
+    skeleton_image = simple_t()
+    graph = image_to_graph_skan(skeleton_image=skeleton_image)
+
+    expected_node_coordinates = {(10, 10, 5), (10, 10, 10), (10, 10, 15), (10, 15, 10)}
+    # make sure the node coordinates are correct
+    node_attributes = nx.get_node_attributes(graph, name=NODE_COORDINATE_KEY)
+    node_coordinates = {tuple(coordinate) for coordinate in node_attributes.values()}
+    assert node_coordinates == expected_node_coordinates
+
+    # make sure there is the correct number of edges
+    assert graph.number_of_edges() == 3

--- a/tests/graph/test_skeleton_graph.py
+++ b/tests/graph/test_skeleton_graph.py
@@ -1,0 +1,33 @@
+"""Tests for the SkeletonGraph class."""
+
+from skeleplex.graph.skeleton_graph import SkeletonGraph
+
+
+def test_skeleton_graph_equality(simple_t_skeleton_graph):
+    """Test the equality of two SkeletonGraph objects."""
+    assert simple_t_skeleton_graph == simple_t_skeleton_graph
+
+    # check that changing the nodes makes the graphs not equal
+    modified_node_graph = simple_t_skeleton_graph.graph.copy()
+    modified_node_graph.add_node(9000)
+    new_skeleton_graph = SkeletonGraph(graph=modified_node_graph)
+    assert simple_t_skeleton_graph != new_skeleton_graph
+
+    # check that changing the edges makes the graphs not equal
+    modified_edge_graph = simple_t_skeleton_graph.graph.copy()
+    modified_edge_graph.add_edge(0, 15)
+    new_skeleton_graph = SkeletonGraph(graph=modified_edge_graph)
+    assert simple_t_skeleton_graph != new_skeleton_graph
+
+
+def test_skeleton_graph_json_round_trip(simple_t_skeleton_graph, tmp_path):
+    """Test writing and reading a SkeletonGraph object"""
+    # write the graph to a file
+    file_path = tmp_path / "test.json"
+    simple_t_skeleton_graph.to_json_file(file_path)
+
+    # read the graph from the file
+    new_skeleton_graph = SkeletonGraph.from_json_file(file_path)
+
+    # check that the graphs are equal
+    assert simple_t_skeleton_graph == new_skeleton_graph

--- a/tests/test_skeleplex.py
+++ b/tests/test_skeleplex.py
@@ -1,2 +1,0 @@
-def test_something():
-    pass


### PR DESCRIPTION
This PR adds the initial basic functionality to convert a skeleton image to a skeleton graph. These functions will only work if everything can fit in memory. I will address large-than-memory methods in a future PR.