### PR TITLE
Add spline model

### DIFF
--- a/examples/fit_skeleton_image.py
+++ b/examples/fit_skeleton_image.py
@@ -8,12 +8,16 @@ import numpy as np
 from skeleplex.data import big_t
 from skeleplex.graph import SkeletonGraph
 
+# load an example skeleton image
 skeleton_image = big_t()
 
+# construct the skeleton graph
 skeleton_graph = SkeletonGraph.from_skeleton_image(skeleton_image)
 
+# get the coordinates of each node
 node_coordinates = skeleton_graph.node_coordinates_array
 
+# make the napari viewer
 viewer = napari.view_image(skeleton_image)
 viewer.add_points(node_coordinates)
 
@@ -21,7 +25,10 @@ viewer.add_points(node_coordinates)
 sample_points = np.linspace(0, 1, 5, endpoint=True)
 colors = cycle(["magenta", "green", "blue", "yellow", "purple"])
 for edge_key, edge_spline in skeleton_graph.edge_splines.items():
+    # get points along the edge spline
     edge_points = edge_spline.eval(sample_points)
+
+    # add a shapes layer for the edge
     viewer.add_shapes(
         edge_points,
         shape_type="path",

--- a/examples/fit_skeleton_image.py
+++ b/examples/fit_skeleton_image.py
@@ -1,0 +1,37 @@
+"""Example of fitting a skeleton graph to a skeleton image."""
+
+from itertools import cycle
+
+import napari
+import numpy as np
+
+from skeleplex.data import big_t
+from skeleplex.graph import SkeletonGraph
+
+skeleton_image = big_t()
+
+skeleton_graph = SkeletonGraph.from_skeleton_image(skeleton_image)
+
+node_coordinates = skeleton_graph.node_coordinates_array
+
+viewer = napari.view_image(skeleton_image)
+viewer.add_points(node_coordinates)
+
+# draw the edge splines
+sample_points = np.linspace(0, 1, 5, endpoint=True)
+colors = cycle(["magenta", "green", "blue", "yellow", "purple"])
+for edge_key, edge_spline in skeleton_graph.edge_splines.items():
+    edge_points = edge_spline.eval(sample_points)
+    viewer.add_shapes(
+        edge_points,
+        shape_type="path",
+        edge_color=next(colors),
+        edge_width=0.2,
+        name=f"edge {edge_key}",
+    )
+
+viewer.dims.ndisplay = 3
+
+
+if __name__ == "__main__":
+    napari.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 dependencies = [
     "einops>=0.8.0",
     "h5py>=3.12.1",
+    "networkx>=3.4",
     "numba>=0.60.0",
     "numpy>=2.0.2",
     "scikit-image>=0.24.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 ]
 # add your package dependencies here
 dependencies = [
+    "einops>=0.8.0",
     "h5py>=3.12.1",
     "numba>=0.60.0",
     "numpy>=2.0.2",

--- a/src/skeleplex/data/__init__.py
+++ b/src/skeleplex/data/__init__.py
@@ -1,5 +1,5 @@
 """Example data."""
 
-from skeleplex.data.skeleton_image import simple_t
+from skeleplex.data.skeleton_image import big_t, simple_t
 
-__all__ = ["simple_t"]
+__all__ = ["big_t", "simple_t"]

--- a/src/skeleplex/data/skeleton_image.py
+++ b/src/skeleplex/data/skeleton_image.py
@@ -28,3 +28,29 @@ def simple_t() -> np.ndarray:
         image[10, rr, cc] = 1
 
     return image
+
+
+def big_t() -> np.ndarray:
+    """Make an image with a big T skeleton.
+
+    Returns
+    -------
+    np.ndarray
+        A binary image with a big T skeleton.
+        The image has shape (100, 100, 100)
+    """
+    # node coordinates for each branch
+    branch_coordinates = [
+        [(50, 25), (50, 50)],
+        [(50, 50), (50, 75)],
+        [(50, 50), (75, 50)],
+    ]
+
+    # draw the image
+    image = np.zeros((100, 100, 100), dtype=bool)
+
+    for branch in branch_coordinates:
+        rr, cc = line(*branch[0], *branch[1])
+        image[50, rr, cc] = 1
+
+    return image

--- a/src/skeleplex/graph/__init__.py
+++ b/src/skeleplex/graph/__init__.py
@@ -1,1 +1,5 @@
 """Tools to create a graph of a skeleton."""
+
+from skeleplex.graph.skeleton_graph import SkeletonGraph
+
+__all__ = ["SkeletonGraph"]

--- a/src/skeleplex/graph/constants.py
+++ b/src/skeleplex/graph/constants.py
@@ -4,3 +4,4 @@ Generally, these are property or key names.
 """
 
 NODE_COORDINATE_KEY = "node_coordinate"
+EDGE_SPLINE_KEY = "spline"

--- a/src/skeleplex/graph/image_to_graph.py
+++ b/src/skeleplex/graph/image_to_graph.py
@@ -2,11 +2,11 @@
 
 import networkx as nx
 import numpy as np
-import splinebox
 from skan.csr import Skeleton as SkanSkeleton
 from skan.csr import summarize
 
 from skeleplex.graph.constants import NODE_COORDINATE_KEY
+from skeleplex.graph.spline import B3Spline
 
 
 def image_to_graph_skan(
@@ -52,10 +52,10 @@ def image_to_graph_skan(
             n_spline_knots = n_points - 1
         else:
             n_spline_knots = max_spline_knots
-        basis_function = splinebox.B3()
-        spline = splinebox.Spline(n_spline_knots, basis_function)
-        spline.fit(spline_path)
-
+        spline = B3Spline.from_points(
+            points=spline_path,
+            n_knots=n_spline_knots,
+        )
         # Nodes are added if they don't exist so only need to add edges
         skeleton_graph.add_edge(
             i,

--- a/src/skeleplex/graph/sample.py
+++ b/src/skeleplex/graph/sample.py
@@ -1,0 +1,110 @@
+"""Functions for sampling images using the SkeletonGraph."""
+
+import einops
+import numpy as np
+from scipy.ndimage import map_coordinates
+
+
+def generate_3d_grid(
+    grid_shape: tuple[int, int, int] = (10, 10, 10),
+    grid_spacing: tuple[float, float, float] = (1, 1, 1),
+) -> np.ndarray:
+    """
+    Generate a 3D sampling grid with specified shape and spacing.
+
+    The grid generated is centered on the origin, has shape (w, h, d, 3) for
+    grid_shape (w, h, d), and spacing grid_spacing between neighboring points.
+
+    Parameters
+    ----------
+    grid_shape : Tuple[int, int, int]
+        The number of grid points along each axis.
+    grid_spacing : Tuple[float, float, float]
+        Spacing between points in the sampling grid.
+
+    Returns
+    -------
+    np.ndarray
+        Coordinate of points forming the 3D grid.
+    """
+    # generate a grid of points at each integer from 0 to grid_shape for each dimension
+    grid = np.indices(grid_shape).astype(float)
+    grid = einops.rearrange(grid, "xyz w h d -> w h d xyz")
+    # shift the grid to be centered on the origin
+    grid_offset = (np.array(grid_shape)) // 2
+    grid -= grid_offset
+    # scale the grid to get correct spacing
+    grid *= grid_spacing
+    return grid
+
+
+def generate_2d_grid(
+    grid_shape: tuple[int, int] = (10, 10), grid_spacing: tuple[float, float] = (1, 1)
+) -> np.ndarray:
+    """
+    Generate a 2D sampling grid with specified shape and spacing.
+
+    The grid generated is centered on the origin, lying on the plane with normal
+    vector [1, 0, 0], has shape (w, h, 3) for grid_shape (w, h), and spacing
+    grid_spacing between neighboring points.
+
+    Parameters
+    ----------
+    grid_shape : Tuple[int, int]
+        The number of grid points along each axis.
+    grid_spacing : Tuple[float, float]
+        Spacing between points in the sampling grid.
+
+    Returns
+    -------
+    np.ndarray
+        Coordinate of points forming the 2D grid.
+    """
+    grid = generate_3d_grid(
+        grid_shape=(1, *grid_shape), grid_spacing=(1, *grid_spacing)
+    )
+    return einops.rearrange(grid, "1 w h xyz -> w h xyz")
+
+
+def sample_volume_at_coordinates(
+    volume: np.ndarray,
+    coordinates: np.ndarray,
+    interpolation_order: int = 3,
+    fill_value: float = np.nan,
+) -> np.ndarray:
+    """
+    Sample a volume with spline interpolation at specific coordinates.
+
+    The output shape is determined by the input coordinate shape such that
+    if coordinates have shape (batch, *grid_shape, 3), the output array will have
+    shape (*grid_shape, batch).
+
+    Parameters
+    ----------
+    volume : np.ndarray
+        Volume to be sampled.
+    coordinates : np.ndarray
+        Array of coordinates at which to sample the volume. The shape of this array
+        should be (batch, *grid_shape, 3) to allow reshaping back correctly
+    interpolation_order : int
+        Spline order for image interpolation.
+    fill_value : float
+        Value to fill in for sample coordinates past the edges of the volume.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape (*grid_shape)
+    """
+    batch, *grid_shape, _ = coordinates.shape
+    # map_coordinates wants transposed coordinate array
+    sampled_volume = map_coordinates(
+        volume,
+        coordinates.reshape(-1, 3).T,
+        order=interpolation_order,
+        cval=fill_value,
+    )
+    # reshape back (need to invert due to previous transposition)
+    sampled_volume = sampled_volume.reshape(*grid_shape, batch)
+    # and retranspose to get batch back to the 0th dimension
+    return einops.rearrange(sampled_volume, "... batch -> batch ...")

--- a/src/skeleplex/graph/spline.py
+++ b/src/skeleplex/graph/spline.py
@@ -1,0 +1,73 @@
+"""Utilities for fitting and working with splines."""
+
+import numpy as np
+import splinebox
+
+
+class B3Spline:
+    """Model for a B3 spline.
+
+    Parameters
+    ----------
+    model : Spline
+        The spline model.
+    """
+
+    _backend = "splinebox"
+
+    def __init__(self, model: splinebox.Spline):
+        self._model = model
+
+    @property
+    def model(self) -> splinebox.Spline:
+        """Return the underlying spline model."""
+        return self._model
+
+    @property
+    def arc_length(self) -> float:
+        """Return the arc length of the spline."""
+        return self.model.arc_length()
+
+    def eval(
+        self, positions: np.ndarray, derivative: int = 0, atol: float = 1e-6
+    ) -> np.ndarray:
+        """Evaluate the spline at a set of positions.
+
+        Parameters
+        ----------
+        positions : np.ndarray
+            (n,) array of positions to evaluate the spline at.
+            The positions are normalized to the range [0, 1].
+        derivative : int
+            The order of the derivative to evaluate.
+            Default value is 0.
+        atol : float
+            The absolute tolerance for converting the normalized
+            evaluation positions to positions along the spline.
+            Default value is 1e-6.
+        """
+        # convert the normalized arc length coordinates to t
+        positions_t = self.model.arc_length_to_parameter(
+            positions * self.arc_length, atol=atol
+        )
+        return self.model.eval(positions_t, derivative=derivative)
+
+    @classmethod
+    def from_points(cls, points: np.ndarray, n_knots: int = 4):
+        """Construct a B3 spline fit to a list of points.
+
+        Parameters
+        ----------
+        points : np.ndarray
+            (n, d) array of points to fit the spline to.
+            These must be ordered in the positive t direction
+            of the spline.
+        n_knots : int
+            The number of knots to use in the spline.
+        """
+        basis_function = splinebox.B3()
+        spline = splinebox.Spline(
+            M=n_knots, basis_function=basis_function, closed=False
+        )
+        spline.fit(points)
+        return cls(model=spline)

--- a/src/skeleplex/graph/spline.py
+++ b/src/skeleplex/graph/spline.py
@@ -166,7 +166,7 @@ class B3Spline:
             )
         spline_model_dict.update({"__class__": "splinebox.Spline"})
         return {
-            "__class__": "B3Spline",
+            "__class__": "skeleplex.B3Spline",
             "model": spline_model_dict,
             "backend": self._backend,
         }
@@ -186,6 +186,13 @@ class B3Spline:
 
         # load the spline model
         spline_model_dict = json_dict["model"]
+
+        if isinstance(spline_model_dict, splinebox.Spline):
+            # model has already been deserialized
+            # this can happen if a this is being called
+            # within another JSON decoder.
+            return cls(model=spline_model_dict)
+
         spline_model_dict.pop("__class__")
         spline_kwargs = _prepared_dict_for_constructor(spline_model_dict)
         spline_model = splinebox.Spline(**spline_kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 """Fixtures for testing with Pytest."""
 
+import numpy as np
 import pytest
 
 from skeleplex.data.skeleton_image import simple_t
 from skeleplex.graph.image_to_graph import image_to_graph_skan
 from skeleplex.graph.skeleton_graph import SkeletonGraph
+from skeleplex.graph.spline import B3Spline
 
 
 @pytest.fixture
@@ -17,3 +19,24 @@ def simple_t_skeleton_graph():
     graph = image_to_graph_skan(skeleton_image=skeleton_image)
 
     return SkeletonGraph(graph=graph)
+
+
+@pytest.fixture
+def simple_spline():
+    """Return a simple B3 spline.
+
+    The spline goes in straight line from (0, 0, 0) to (1, 0, 0).
+    """
+    # make three points that go from x=0 to x=1
+    points = np.array(
+        [
+            [0, 0, 0],
+            [0.25, 0, 0],
+            [0.5, 0, 0],
+            [0.75, 0, 0],
+            [1, 0, 0],
+        ]
+    )
+
+    # fit a spline to the points
+    return B3Spline.from_points(points)

--- a/tests/graph/test_spline.py
+++ b/tests/graph/test_spline.py
@@ -4,6 +4,7 @@ from skeleplex.graph.spline import B3Spline
 
 
 def test_uniform_sampling():
+    """Test uniform sampling of a spline."""
     # make three points that go from x=0 to x=1
     points = np.array(
         [

--- a/tests/graph/test_spline.py
+++ b/tests/graph/test_spline.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from skeleplex.graph.spline import B3Spline
+
+
+def test_uniform_sampling():
+    # make three points that go from x=0 to x=1
+    points = np.array(
+        [
+            [0, 0, 0],
+            [0.25, 0, 0],
+            [0.5, 0, 0],
+            [0.75, 0, 0],
+            [1, 0, 0],
+        ]
+    )
+
+    # fit a spline to the points
+    spline = B3Spline.from_points(points)
+
+    # sample the spline uniformly in arc length
+    sample_points = np.linspace(0, 1, 11, endpoint=True)
+    spline_points = spline.eval(sample_points)
+
+    expected_points = np.column_stack((sample_points, np.zeros((11, 2))))
+    np.testing.assert_allclose(spline_points, expected_points, atol=1e-6)

--- a/tests/graph/test_spline.py
+++ b/tests/graph/test_spline.py
@@ -3,9 +3,24 @@ import numpy as np
 from skeleplex.graph.spline import B3Spline
 
 
-def test_uniform_sampling():
+def test_uniform_sampling(simple_spline):
     """Test uniform sampling of a spline."""
-    # make three points that go from x=0 to x=1
+    # sample the spline uniformly in arc length
+    sample_points = np.linspace(0, 1, 11, endpoint=True)
+    spline_points = simple_spline.eval(sample_points)
+
+    expected_points = np.column_stack((sample_points, np.zeros((11, 2))))
+    np.testing.assert_allclose(spline_points, expected_points, atol=1e-6)
+
+
+def test_spline_equality(simple_spline):
+    """Test spline equality."""
+    # create a new spline that is the same as the original
+    new_spline = B3Spline(model=simple_spline.model)
+
+    assert simple_spline == new_spline
+
+    # create a different spline
     points = np.array(
         [
             [0, 0, 0],
@@ -15,13 +30,17 @@ def test_uniform_sampling():
             [1, 0, 0],
         ]
     )
+    different_spline = B3Spline.from_points(points, n_knots=5)
+    assert simple_spline != different_spline
 
-    # fit a spline to the points
-    spline = B3Spline.from_points(points)
 
-    # sample the spline uniformly in arc length
-    sample_points = np.linspace(0, 1, 11, endpoint=True)
-    spline_points = spline.eval(sample_points)
+def test_spline_serialization(simple_spline, tmp_path):
+    """Test spline serialization."""
+    # save the spline to a file
+    file_path = tmp_path / "spline.json"
+    simple_spline.to_json_file(file_path)
 
-    expected_points = np.column_stack((sample_points, np.zeros((11, 2))))
-    np.testing.assert_allclose(spline_points, expected_points, atol=1e-6)
+    # load the spline from the file
+    reloaded_spline = B3Spline.from_json_file(file_path)
+
+    assert simple_spline == reloaded_spline


### PR DESCRIPTION
This PR implements an initial version of spline fitting using `splinebox`. This implements:
- fitting of the splines
- sampling the splines using a normalized arc length coordinate.
- sampling images using the spline
- serialization/deserialization to/from json

This PR does not:
- implement a smart way to automatically choose the number of knots for the spline (https://github.com/kevinyamauchi/skeleplex_v2/issues/7)
- allow for the boundary conditions of the spline fit to be set