### PR TITLE
add function to get the next node key

### DIFF
--- a/src/skeleplex/graph/skeleton_graph.py
+++ b/src/skeleplex/graph/skeleton_graph.py
@@ -106,6 +106,26 @@ def make_graph_directed(graph: nx.Graph, origin: int) -> nx.DiGraph:
     return di_graph
 
 
+def get_next_node_key(graph: nx.Graph) -> int:
+    """Return the next available node key in the graph.
+
+    This function assumes the graph node keys are integers.
+
+    Parameters
+    ----------
+    graph : nx.Graph
+        The graph to get the next node key from.
+
+    Returns
+    -------
+    int
+        The next available node key.
+        This is the maximum node key + 1.
+        If there are no nodes, the function returns 0.
+    """
+    return int(np.max(graph.nodes)) + 1 if graph.nodes else 0
+
+
 class SkeletonGraph:
     """Data class for a skeleton graph.
 

--- a/tests/graph/test_skeleton_graph.py
+++ b/tests/graph/test_skeleton_graph.py
@@ -1,6 +1,8 @@
 """Tests for the SkeletonGraph class."""
 
-from skeleplex.graph.skeleton_graph import SkeletonGraph
+import networkx as nx
+
+from skeleplex.graph.skeleton_graph import SkeletonGraph, get_next_node_key
 
 
 def test_skeleton_graph_equality(simple_t_skeleton_graph):
@@ -49,3 +51,19 @@ def test_skeleton_graph_to_directed(simple_t_skeleton_graph):
         assert all(
             edges in directed_graph.out_edges(u) for edges in directed_graph.in_edges(v)
         )
+
+
+def test_get_next_node_id():
+    """Test the get_next_node_id function."""
+    # initialize an empty graph
+    graph = nx.Graph()
+
+    assert get_next_node_key(graph) == 0
+
+    # add a node to the graph
+    graph.add_node(0)
+    assert get_next_node_key(graph) == 1
+
+    # add multiple nodes to the graph
+    graph.add_nodes_from([10, 23, 65])
+    assert get_next_node_key(graph) == 66


### PR DESCRIPTION
This PR adds a function to get the next node key for a graph. It returns the max node key + 1. This will be used for getting a key when adding nodes to a graph.

This approach may get slow as the graphs get large, so we will have to consider if there is a better way in the future (e.g., UUIDs).

closes #14 