### PR TITLE
Function to check orientation of splines

### DIFF
--- a/src/skeleplex/graph/constants.py
+++ b/src/skeleplex/graph/constants.py
@@ -5,3 +5,4 @@ Generally, these are property or key names.
 
 NODE_COORDINATE_KEY = "node_coordinate"
 EDGE_SPLINE_KEY = "spline"
+EDGE_COORDINATES_KEY = "path"

--- a/src/skeleplex/graph/skeleton_graph.py
+++ b/src/skeleplex/graph/skeleton_graph.py
@@ -49,7 +49,8 @@ def skeleton_graph_decoder(json_object):
             return B3Spline.from_json_dict(json_object)
     return json_object
 
-def make_graph_directed(graph: nx.Graph, origin = int) -> nx.DiGraph:
+
+def make_graph_directed(graph: nx.Graph, origin=int) -> nx.DiGraph:
     """Return a directed graph from an undirected graph.
 
     The directed graph has the same nodes and edges as the undirected graph.
@@ -62,27 +63,36 @@ def make_graph_directed(graph: nx.Graph, origin = int) -> nx.DiGraph:
         The node to use as the origin node for the directed graph.
         The origin node will have no incoming edges.
     """
-    if type(graph) == nx.DiGraph:   
+    if isinstance(graph, nx.DiGraph):
         print("The input graph is already a directed graph.")
         return graph
-    if len([component for component in nx.connected_components(graph)]) >1:
+    if len(list(nx.connected_components(graph))) > 1:
         Warning("""
-        The input graph is not connected. 
-        The unconnected components will contain multiple edges.
+        The input graph is not connected.
+        The unconnected components might lose edges
         """)
-        orgin_part = nx.node_connected_component(graph, origin)
-        fragments = graph.subgraph(set(graph.nodes()) - orgin_part)
-        graph = graph.subgraph(orgin_part)
+        origin_part = nx.node_connected_component(graph, origin)
+        fragments = graph.subgraph(set(graph.nodes()) - origin_part)
+        graph = graph.subgraph(origin_part)
     else:
         fragments = None
-    
+
     di_graph = nx.DiGraph(graph)
     di_graph.remove_edges_from(di_graph.edges - nx.bfs_edges(di_graph, origin))
 
     if fragments:
-        fragments = fragments.to_directed()
-        di_graph.add_edges_from(fragments.edges(data = True))
-        di_graph.add_nodes_from(fragments.nodes(data = True))
+        # choose a node with the highest degree as the origin node
+        # This could lead to the wrong edges being removed, but it is a good start
+        for fragment in nx.connected_components(fragments):
+            fragment_subgraph = fragments.subgraph(fragment)
+            origin = max(fragment_subgraph.degree, key=lambda x: x[1])[0]
+            di_fragment = nx.DiGraph(fragment_subgraph)
+            di_fragment.remove_edges_from(
+                di_fragment.edges - nx.bfs_edges(di_fragment, origin)
+            )
+            di_graph.add_edges_from(di_fragment.edges(data=True))
+            di_graph.add_nodes_from(di_fragment.nodes(data=True))
+
     return di_graph
 
 
@@ -181,7 +191,6 @@ class SkeletonGraph:
             skeleton_image=skeleton_image, max_spline_knots=max_spline_knots
         )
         return cls(graph=graph)
-    
 
     def __eq__(self, other: "SkeletonGraph"):
         """Check if two SkeletonGraph objects are equal."""
@@ -193,8 +202,8 @@ class SkeletonGraph:
             return False
         else:
             return True
-        
-    def to_directed(self, origin = int) -> nx.DiGraph:
+
+    def to_directed(self, origin=int) -> nx.DiGraph:
         """Return a directed graph from the skeleton graph.
 
         The directed graph has the same nodes and edges as the skeleton graph.
@@ -207,4 +216,3 @@ class SkeletonGraph:
         """
         self.graph = make_graph_directed(self.graph, origin)
         return self.graph
-

--- a/src/skeleplex/graph/spline.py
+++ b/src/skeleplex/graph/spline.py
@@ -226,3 +226,20 @@ class B3Spline:
         )
         spline.fit(points)
         return cls(model=spline)
+
+    def flip_spline(self, path: np.ndarray) -> "B3Spline":
+        """Recomputes the spline inverse to the path.
+
+        Parameters
+        ----------
+        path : np.ndarray
+            The coordinates to fit the spline to.
+
+        Returns
+        -------
+        B3Spline
+            The flipped spline.
+        np.ndarray
+            The flipped path coordinates.
+        """
+        return self.from_points(path[::-1]), path[::-1]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,22 +1,68 @@
 """Fixtures for testing with Pytest."""
 
+import networkx as nx
 import numpy as np
 import pytest
 
-from skeleplex.data.skeleton_image import simple_t
-from skeleplex.graph.image_to_graph import image_to_graph_skan
+from skeleplex.graph.constants import (
+    EDGE_COORDINATES_KEY,
+    EDGE_SPLINE_KEY,
+    NODE_COORDINATE_KEY,
+)
 from skeleplex.graph.skeleton_graph import SkeletonGraph
 from skeleplex.graph.spline import B3Spline
 
 
 @pytest.fixture
 def simple_t_skeleton_graph():
-    """Return the simple T skeleton as a graph.
+    """Return the simple T skeleton as a graph."""
+    graph = nx.DiGraph()
+    # add nodes
+    graph.add_node(0, **{NODE_COORDINATE_KEY: np.array([10, 0, 0])})
+    graph.add_node(1, **{NODE_COORDINATE_KEY: np.array([10, 10, 0])})
+    graph.add_node(2, **{NODE_COORDINATE_KEY: np.array([0, 10, 0])})
+    graph.add_node(3, **{NODE_COORDINATE_KEY: np.array([20, 10, 0])})
 
-    Todo: replace with valid data rather than a processed object.
-    """
-    skeleton_image = simple_t()
-    graph = image_to_graph_skan(skeleton_image=skeleton_image)
+    # add edge coordinates
+    # flipped edge
+    graph.add_edge(
+        0, 1, **{EDGE_COORDINATES_KEY: np.linspace([10, 0, 0], [10, 10, 0], 4)}
+    )
+    graph.add_edge(
+        1, 2, **{EDGE_COORDINATES_KEY: np.linspace([10, 10, 0], [0, 10, 0], 4)}
+    )
+    graph.add_edge(
+        1, 3, **{EDGE_COORDINATES_KEY: np.linspace([10, 10, 0], [20, 10, 0], 4)}
+    )
+
+    # add spline
+    graph.add_edge(
+        0,
+        1,
+        **{
+            EDGE_SPLINE_KEY: B3Spline.from_points(
+                np.linspace([10, 0, 0], [10, 10, 0], 4)
+            )
+        },
+    )
+    graph.add_edge(
+        1,
+        2,
+        **{
+            EDGE_SPLINE_KEY: B3Spline.from_points(
+                np.linspace([10, 10, 0], [0, 10, 0], 4)
+            )
+        },
+    )
+    graph.add_edge(
+        1,
+        3,
+        **{
+            EDGE_SPLINE_KEY: B3Spline.from_points(
+                np.linspace([10, 10, 0], [20, 10, 0], 4)
+            )
+        },
+    )
 
     return SkeletonGraph(graph=graph)
 
@@ -40,3 +86,61 @@ def simple_spline():
 
     # fit a spline to the points
     return B3Spline.from_points(points)
+
+
+@pytest.fixture
+def simple_t_with_flipped_spline():
+    """Return the simple T skeleton as a graph with a flipped spline."""
+
+    graph = nx.DiGraph()
+    # add nodes
+    graph.add_node(0, **{NODE_COORDINATE_KEY: np.array([10, 0, 0])})
+    graph.add_node(1, **{NODE_COORDINATE_KEY: np.array([10, 10, 0])})
+    graph.add_node(2, **{NODE_COORDINATE_KEY: np.array([0, 10, 0])})
+    graph.add_node(3, **{NODE_COORDINATE_KEY: np.array([20, 10, 0])})
+
+    # add edge coordinates
+    # flipped edge
+    graph.add_edge(
+        0, 1, **{EDGE_COORDINATES_KEY: np.linspace([10, 10, 0], [10, 0, 0], 4)}
+    )
+
+    graph.add_edge(
+        1, 2, **{EDGE_COORDINATES_KEY: np.linspace([10, 10, 0], [0, 10, 0], 4)}
+    )
+    graph.add_edge(
+        1, 3, **{EDGE_COORDINATES_KEY: np.linspace([10, 10, 0], [20, 10, 0], 4)}
+    )
+
+    # add spline
+    # flipped spline
+    graph.add_edge(
+        0,
+        1,
+        **{
+            EDGE_SPLINE_KEY: B3Spline.from_points(
+                np.linspace([10, 10, 0], [10, 0, 0], 4)
+            )
+        },
+    )
+
+    graph.add_edge(
+        1,
+        2,
+        **{
+            EDGE_SPLINE_KEY: B3Spline.from_points(
+                np.linspace([10, 10, 0], [0, 10, 0], 4)
+            )
+        },
+    )
+    graph.add_edge(
+        1,
+        3,
+        **{
+            EDGE_SPLINE_KEY: B3Spline.from_points(
+                np.linspace([10, 10, 0], [20, 10, 0], 4)
+            )
+        },
+    )
+
+    return graph

--- a/tests/graph/test_skeleton_graph.py
+++ b/tests/graph/test_skeleton_graph.py
@@ -32,10 +32,20 @@ def test_skeleton_graph_json_round_trip(simple_t_skeleton_graph, tmp_path):
     # check that the graphs are equal
     assert simple_t_skeleton_graph == new_skeleton_graph
 
+
 def test_skeleton_graph_to_directed(simple_t_skeleton_graph):
     """Test converting a SkeletonGraph to a directed graph."""
-    directed_graph = simple_t_skeleton_graph.graph.to_directed()
+    directed_graph = simple_t_skeleton_graph.to_directed(origin=0)
     assert directed_graph.is_directed()
 
     # check that the directed graph has the same nodes
     assert set(directed_graph.nodes) == set(simple_t_skeleton_graph.graph.nodes)
+
+    # check if the origin node has no incoming edges
+    assert len(list(directed_graph.in_edges(0))) == 0
+
+    # check edge directionality
+    for u, v in directed_graph.edges:
+        assert all(
+            edges in directed_graph.out_edges(u) for edges in directed_graph.in_edges(v)
+        )

--- a/tests/graph/test_skeleton_graph.py
+++ b/tests/graph/test_skeleton_graph.py
@@ -31,3 +31,11 @@ def test_skeleton_graph_json_round_trip(simple_t_skeleton_graph, tmp_path):
 
     # check that the graphs are equal
     assert simple_t_skeleton_graph == new_skeleton_graph
+
+def test_skeleton_graph_to_directed(simple_t_skeleton_graph):
+    """Test converting a SkeletonGraph to a directed graph."""
+    directed_graph = simple_t_skeleton_graph.graph.to_directed()
+    assert directed_graph.is_directed()
+
+    # check that the directed graph has the same nodes
+    assert set(directed_graph.nodes) == set(simple_t_skeleton_graph.graph.nodes)

--- a/tests/graph/test_spline.py
+++ b/tests/graph/test_spline.py
@@ -50,6 +50,7 @@ def test_spline_flipping(simple_spline):
     """Test if spline is getting flipped correctly."""
 
     eval_points = simple_spline.eval(np.linspace(0, 1, 4))
+    # flip the spline
     flipped_spline, flipped_coords = simple_spline.flip_spline(eval_points)
 
     # test if the flipping changed the spline

--- a/tests/graph/test_spline.py
+++ b/tests/graph/test_spline.py
@@ -44,3 +44,23 @@ def test_spline_serialization(simple_spline, tmp_path):
     reloaded_spline = B3Spline.from_json_file(file_path)
 
     assert simple_spline == reloaded_spline
+
+
+def test_spline_flipping(simple_spline):
+    """Test if spline is getting flipped correctly."""
+
+    eval_points = simple_spline.eval(np.linspace(0, 1, 4))
+    flipped_spline, flipped_coords = simple_spline.flip_spline(eval_points)
+
+    # test if the flipping changed the spline
+    with np.testing.assert_raises(AssertionError):
+        np.testing.assert_allclose(
+            eval_points, flipped_spline.eval(np.linspace(0, 1, 4)), atol=1e-2
+        )
+
+    # test if the flipping changed the coordinates to the inverse
+    np.testing.assert_allclose(
+        eval_points[::-1], flipped_spline.eval(np.linspace(0, 1, 4)), atol=1e-2
+    )
+    # test if the coordinates are flipped
+    np.testing.assert_allclose(eval_points[::-1], flipped_coords, atol=1e-2)


### PR DESCRIPTION
A new method in the SkeletonGraph object that controls and if necessary aligns the splines so that they connect nodes with the right orientation. If there needs to be flipping, the original edge coordinates are used to fit a spline in the right direction.