### PR TITLE
Fix scaling of image to graph

### DIFF
--- a/src/skeleplex/data/fractal_trees.py
+++ b/src/skeleplex/data/fractal_trees.py
@@ -238,8 +238,11 @@ def generate_random_parameters_for_fractal_tree(
     noise_magnitude_range: tuple[float, float] = (5, 15),
     ellipse_ratio_range: tuple[float, float] = (1.1, 1.5),
     dilation_size: int = 3,
+    tip_dilation_size: float = (1.05, 1.2),
     use_gpu=True,
     seed: int = 42,
+    inplane_rotation: float | None = (-20, 20),
+    outplane_rotation: list[float, float, float] | None = None,
 ):
     """Generate random parameters for fractal tree generation."""
     seed_gen = np.random.default_rng(seed)
@@ -251,14 +254,26 @@ def generate_random_parameters_for_fractal_tree(
     ellipse_ratio = (
         seed_gen.uniform(*ellipse_ratio_range) if seed_gen.random() > 0.5 else None
     )
+    tip_dilation_size = seed_gen.uniform(*tip_dilation_size)
+    if inplane_rotation is not None:
+        inplane_rotation = seed_gen.uniform(*inplane_rotation)
+    if outplane_rotation is not None:
+        outplane_rotation = [
+            seed_gen.uniform(*outplane_rotation[0]),
+            seed_gen.uniform(*outplane_rotation[1]),
+            seed_gen.uniform(*outplane_rotation[2]),
+        ]
     return (
         num_nodes,
         edge_length,
         branch_angle,
         wiggle_factor,
         noise_magnitude,
-        ellipse_ratio,
         dilation_size,
+        tip_dilation_size,
+        ellipse_ratio,
         use_gpu,
         seed,
+        inplane_rotation,
+        outplane_rotation,
     )

--- a/src/skeleplex/data/fractal_trees.py
+++ b/src/skeleplex/data/fractal_trees.py
@@ -61,6 +61,7 @@ def generate_synthetic_fractal_tree(
     wiggle_factor: float = 0.01,
     noise_magnitude: float = 5,
     dilation_size: int = 3,
+    tip_dilation_size: int = 1.05,
     ellipse_ratio: float | None = None,
     use_gpu: bool = True,
     seed: int = 42,
@@ -88,6 +89,9 @@ def generate_synthetic_fractal_tree(
     dilation_size : int, optional
         Size of the dilation applied to the skeleton image.
         Default is 3.
+    tip_dilation_size : float, optional
+        Factor to control the size of the dilation applied to the tips of the branches.
+        Default is 1.05.
     ellipse_ratio : float, optional
         Ratio of the radii of the elliptic cylinder segments.
         If None, the branches will be cylindrical.
@@ -192,12 +196,9 @@ def generate_synthetic_fractal_tree(
             branch_img,
             pos,
             radii=(
-                # radius * seed_gen.uniform(1, 1.2),
-                radius * 1.12,
-                # radius * seed_gen.uniform(1, 1.2),
-                radius * 1.12,
-                # radius * seed_gen.uniform(1, 1.2),
-                radius * 1.12,
+                radius * tip_dilation_size,
+                radius * tip_dilation_size,
+                radius * tip_dilation_size,
             ),
         )
 

--- a/src/skeleplex/graph/skeleton_graph.py
+++ b/src/skeleplex/graph/skeleton_graph.py
@@ -456,7 +456,10 @@ class SkeletonGraph:
 
     @classmethod
     def from_skeleton_image(
-        cls, skeleton_image: np.ndarray, max_spline_knots: int = 10
+        cls,
+        skeleton_image: np.ndarray,
+        max_spline_knots: int = 10,
+        image_voxel_size_um: float = 1,
     ) -> "SkeletonGraph":
         """Return a SkeletonGraph from a skeleton image.
 
@@ -469,9 +472,13 @@ class SkeletonGraph:
             If the number of data points in the branch is less than this number,
             the spline will use n_data_points - 1 knots.
             See the splinebox Spline class docs for more information.
+        image_voxel_size_um  : float or array of float
+            Spacing of the voxels. Used to transform graph coordinates to um.
         """
         graph = image_to_graph_skan(
-            skeleton_image=skeleton_image, max_spline_knots=max_spline_knots
+            skeleton_image=skeleton_image,
+            max_spline_knots=max_spline_knots,
+            image_voxel_size_um=image_voxel_size_um,
         )
         return cls(graph=graph)
 


### PR DESCRIPTION
As agreed on in:

https://github.com/kevinyamauchi/skeleplex-v2?tab=readme-ov-file#technical-notes

the coordinates on the graph are supposed to live in um scale. This was not the case for the image_to_graph pipeline and is now fixed.