### PR TITLE
add util to process a lazy array iteratively over chunks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.x
+          python-version: 3.12
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
       - uses: actions/cache@v4
         with:

--- a/src/skeleplex/utils/__init__.py
+++ b/src/skeleplex/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utilities for operating on the skeleton."""
 
+from skeleplex.utils._chunked import iteratively_process_chunks_3d
 from skeleplex.utils._geometry import line_segments_in_aabb, points_in_aabb
 
-__all__ = ["line_segments_in_aabb", "points_in_aabb"]
+__all__ = ["iteratively_process_chunks_3d", "line_segments_in_aabb", "points_in_aabb"]

--- a/src/skeleplex/utils/_chunked.py
+++ b/src/skeleplex/utils/_chunked.py
@@ -1,0 +1,110 @@
+"""Utilities for working with chunked arrays."""
+
+from collections.abc import Callable
+
+import dask.array as da
+import numpy as np
+import zarr
+
+
+def iteratively_process_chunks_3d(
+    input_array: da.Array,
+    output_zarr: zarr.Array,
+    function_to_apply: Callable[[np.ndarray], np.ndarray],
+    chunk_shape: tuple[int, int, int],
+    extra_border: tuple[int, int, int],
+):
+    """Apply a function to each chunk of a Dask array with extra border handling.
+
+    Parameters
+    ----------
+    input_array : dask.array.Array
+        The input Dask array to process. Must be 3D.
+    output_zarr : zarr.Array
+        The output Zarr array to write results to.
+        Must have the same shape as input_array.
+    function_to_apply : Callable[[np.ndarray], np.ndarray]
+        The function to apply to each chunk.
+    chunk_shape : tuple[int, int, int]
+        The shape of each chunk to process.
+    extra_border : tuple[int, int, int]
+        The extra border to include around each chunk.
+    """
+    # validate inputs before processing
+    if input_array.ndim != 3:
+        raise ValueError(f"Input array must be 3D, got {input_array.ndim}D")
+
+    if len(chunk_shape) != 3:
+        raise ValueError(
+            f"chunk_shape must be a 3-tuple, got length {len(chunk_shape)}"
+        )
+
+    if len(extra_border) != 3:
+        raise ValueError(
+            f"extra_border must be a 3-tuple, got length {len(extra_border)}"
+        )
+
+    if input_array.shape != output_zarr.shape:
+        raise ValueError(
+            f"Input and output shapes must match. "
+            f"Got input: {input_array.shape}, output: {output_zarr.shape}"
+        )
+
+    # calculate the chunk grid
+    array_shape = input_array.shape
+    n_chunks = tuple(int(np.ceil(array_shape[i] / chunk_shape[i])) for i in range(3))
+
+    # iterate over all chunks
+    for i in range(n_chunks[0]):
+        for j in range(n_chunks[1]):
+            for k in range(n_chunks[2]):
+                # calculate core chunk slice
+                core_start = (
+                    i * chunk_shape[0],
+                    j * chunk_shape[1],
+                    k * chunk_shape[2],
+                )
+                core_end = (
+                    min((i + 1) * chunk_shape[0], array_shape[0]),
+                    min((j + 1) * chunk_shape[1], array_shape[1]),
+                    min((k + 1) * chunk_shape[2], array_shape[2]),
+                )
+                core_slice = tuple(
+                    slice(core_start[dim], core_end[dim]) for dim in range(3)
+                )
+
+                # calculate expanded slice (chunk + border), clipped to array boundaries
+                expanded_start = tuple(
+                    max(0, core_start[dim] - extra_border[dim]) for dim in range(3)
+                )
+                expanded_end = tuple(
+                    min(array_shape[dim], core_end[dim] + extra_border[dim])
+                    for dim in range(3)
+                )
+                expanded_slice = tuple(
+                    slice(expanded_start[dim], expanded_end[dim]) for dim in range(3)
+                )
+
+                # calculate actual border used (may be smaller at edges)
+                actual_border_before = tuple(
+                    core_start[dim] - expanded_start[dim] for dim in range(3)
+                )
+
+                # extract chunk + border and compute
+                chunk_with_border = input_array[expanded_slice].compute()
+
+                # apply function
+                processed = function_to_apply(chunk_with_border)
+
+                # extract core region from processed result
+                core_in_result_slice = tuple(
+                    slice(
+                        actual_border_before[dim],
+                        actual_border_before[dim] + (core_end[dim] - core_start[dim]),
+                    )
+                    for dim in range(3)
+                )
+                core_result = processed[core_in_result_slice]
+
+                # write to Zarr
+                output_zarr[core_slice] = core_result


### PR DESCRIPTION
This util does iterates over chunks with a specified border and applies the user specified function. it then writes the result for the chunk (i.e., without the border) to a zarr array. this is to avoid edge effects for functions such as convolutions.